### PR TITLE
解决新版本中被自动覆盖的导致通话录音失效的问题。

### DIFF
--- a/common/service.sh
+++ b/common/service.sh
@@ -7,11 +7,16 @@ MODDIR=${0%/*}
 # More info in the main Magisk thread
 sleep 30
 settings put global op_voice_recording_supported_by_mcc 1
-sleep 30
+pm disable com.android.phone/com.android.phone.oneplus.OPSimSubSettingsActivity
+leep 30
 settings put global op_voice_recording_supported_by_mcc 1
-sleep 30
+pm disable com.android.phone/com.android.phone.oneplus.OPSimSubSettingsActivity
+leep 30
 settings put global op_voice_recording_supported_by_mcc 1
-sleep 30
+pm disable com.android.phone/com.android.phone.oneplus.OPSimSubSettingsActivity
+leep 30
 settings put global op_voice_recording_supported_by_mcc 1
-sleep 30
+pm disable com.android.phone/com.android.phone.oneplus.OPSimSubSettingsActivity
+leep 30
 settings put global op_voice_recording_supported_by_mcc 1
+pm disable com.android.phone/com.android.phone.oneplus.OPSimSubSettingsActivity


### PR DESCRIPTION
@shadowstep 我第一个想到你，我把这个好消息告诉你。

I first thought of you, I will tell you this good news.

可以在magsik中增加 如下代码 在sleep 前。

You can add the following code to magsik before sleep.

pm disable com.android.phone/com.android.phone.oneplus.OPSimSubSettingsActivity


hope this helps.

add by 联盟少侠