### PR TITLE
Improve timer for settings service

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This module enables the native call recording feature on OxygenOS (and ROMs base
 Don't forget to **uninstall** *(not the same as disabling)* the module whenever you're planning on updating OOS or else it might create issues. You have been warned! You can reinstall the module after the update.
 
 ## Changelog
+### v9.2
+- Improve race condition handling at boot
+
 ### v9.1
 - Updated base template to MMT-Ex Template v1.5
 - Fixed manufacturer check

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=oosnativecallrecordingenabler
 name=OOS Native Call Recording Enabler
-version=v9.1
-versionCode=91
+version=v9.2
+versionCode=92
 author=@shadowstep and @My Name is ShaoXIa at xda-developers
 description=This module enables the native call recording feature on OxygenOS (and ROMs based on it)
 support=https://forum.xda-developers.com/oneplus-5/themes/app-enable-call-recording-boot-t3634292

--- a/service.sh
+++ b/service.sh
@@ -1,4 +1,20 @@
 #!/system/bin/sh
 # This script will be executed in late_start service mode
-(sleep 10
-settings put global op_voice_recording_supported_by_mcc 1)&
+
+# wait until the settings service is available
+i=0
+settings > /dev/null 2>&1
+until [ $? -eq 255 ]
+do
+    sleep 5
+    i=$((i+1))
+    # if settings is not ready after 2min, stop
+    if [ $i -gt 24 ]
+    then
+        exit 1
+    fi
+
+    settings > /dev/null 2>&1
+done
+
+settings put global op_voice_recording_supported_by_mcc 1


### PR DESCRIPTION
- The settings service is not available at the beginning of late_start because services are launched in this mode. Waiting 10s will be enough in most cases. But this is a race condition and it can be lost sometimes. In order to improve the chances without a waiting time too long for the user, a watcher is added to get when settings service is ready. The watcher timeout after 2min.
- Update module version to 9.2

Thank you for this useful module !